### PR TITLE
Eliminate a few Lens type annotations

### DIFF
--- a/PistachioTests/AdapterSpec.swift
+++ b/PistachioTests/AdapterSpec.swift
@@ -56,7 +56,7 @@ struct Node {
 }
 
 struct NodeLenses {
-    static let children = Lens<Node, [Node]>(get: { $0.children }, set: { (inout node: Node, children) in
+    static let children = Lens(get: { $0.children }, set: { (inout node: Node, children) in
         node.children = children
     })
 }

--- a/PistachioTests/LensSpec.swift
+++ b/PistachioTests/LensSpec.swift
@@ -36,17 +36,17 @@ func == (lhs: Outer, rhs: Outer) -> Bool {
 }
 
 struct OuterLenses {
-    static let count = Lens<Outer, Int>(get: { $0.count }, set: { (inout outer: Outer, count) in
+    static let count = Lens(get: { $0.count }, set: { (inout outer: Outer, count) in
         outer.count = count
     })
 
-    static let inner = Lens<Outer, Inner>(get: { $0.inner }, set: { (inout outer: Outer, inner) in
+    static let inner = Lens(get: { $0.inner }, set: { (inout outer: Outer, inner) in
         outer.inner = inner
     })
 }
 
 struct InnerLenses {
-    static let count = Lens<Inner, Int>(get: { $0.count }, set: { (inout inner: Inner, count) in
+    static let count = Lens(get: { $0.count }, set: { (inout inner: Inner, count) in
         inner.count = count
     })
 }

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Lenses are basically just a combination of a getter and a setter:
 
 ```swift
 struct OriginLenses {
-  static let city = Lens<Origin, String>(get: { $0.city }, set: { (inout origin: Origin, city) in
+  static let city = Lens(get: { $0.city }, set: { (inout origin: Origin, city) in
     origin.city = city
   })
 }
@@ -63,11 +63,11 @@ struct OriginLenses {
 
 ```swift
 struct PersonLenses {
-  static let name = Lens<Person, String>(get: { $0.name }, set: { (inout person: Person, name) in
+  static let name = Lens(get: { $0.name }, set: { (inout person: Person, name) in
     person.name = name
   })
 
-  static let origin = Lens<Person, Origin>(get: { $0.origin }, set: { (inout person: Person, origin) in
+  static let origin = Lens(get: { $0.origin }, set: { (inout person: Person, origin) in
     person.origin = origin
   })
 }
@@ -84,7 +84,7 @@ get(PersonLenses.name, person) // == "Robb"
 And you can compose, lift, transform, [...](https://github.com/felixjendrusch/Pistachio/blob/master/Pistachio/Lens.swift) them:
 
 ```swift
-let composed: Lens<Person, String> = PersonLenses.origin >>> OriginLenses.city
+let composed = PersonLenses.origin >>> OriginLenses.city
 person = set(composed, person, "New York")
 get(composed, person) // == "New York"
 ```


### PR DESCRIPTION
One of my [initial reactions](https://twitter.com/jspahrsummers/status/565580761508888576) to Pistachio (besides, “fuck yeah lenses”) was a bit of disappointment at the number of type annotations required, since I hate to duplicate anything for the compiler.

However, I didn't realize that the level of annotation [given in the README](https://github.com/felixjendrusch/Pistachio/blob/1ef81d27df29bb6f9bc41c0f800e83ef28b8481b/README.md#usage) is actually overkill, and that less will still compile perfectly fine.

So, in short, this is an opinionated change intended to counteract the sort of reaction that I had, by reducing code/type duplication in the README and some of Pistacho's tests. Feel free to accept or reject it! :smile: 
